### PR TITLE
locaties zoeken gesorteerd op beginnen met zoekterm.

### DIFF
--- a/PollenFrontend/src/components/location/customLocation/LocationSearch.tsx
+++ b/PollenFrontend/src/components/location/customLocation/LocationSearch.tsx
@@ -17,14 +17,20 @@ const LocationSearch = ({ locations, onSelectLocation }: Props) => {
         const term = e.target.value;
         setSearchTerm(term);
 
-        if (term.trim() !== '') {
-            const filtered = locations.filter((location) =>
-                location.name.toLowerCase().includes(term.toLowerCase())
-            );
-            setFilteredLocations(filtered);
-        } else {
+        if (term === '') {
             setFilteredLocations([]);
+            return;
         }
+
+        const filtered = locations.filter((location) =>
+            location.name.toLowerCase().includes(term.toLowerCase())
+        ).sort((a, b) => {
+            const key = term.toLowerCase();
+            const isGoodMatchA = a.name.toLowerCase().startsWith(key);
+            const isGoodMatchB = b.name.toLowerCase().startsWith(key);
+            return Number(isGoodMatchB) - Number(isGoodMatchA);
+        });
+        setFilteredLocations(filtered);
     };
 
     const handleLocationSelect = (location: LocationData) => {


### PR DESCRIPTION
bij het zoeken worden de locaties die beginnen met de zoekterm nu als eerste gesorteerd. Dit maakt zoeken wat intuïtiever.

Als je bijvoorbeeld zoekt op Ren worden de locaties die beginnen met Ren eerst getoond. Omdat je een locatie van links naar rechts typt is dat wat intuïtiever.
![image](https://github.com/user-attachments/assets/4a5843f6-7106-4609-9c01-c29723e11324)

voor de sortering. moet je dan eerst gaan scrollen of verder uittypen.
![image](https://github.com/user-attachments/assets/fbddf67e-9b44-41a6-bd51-ac6b6871fc6f)

